### PR TITLE
Remove suggestion to buy local

### DIFF
--- a/_content/en/02-do/12-look-beyond-yourself.md
+++ b/_content/en/02-do/12-look-beyond-yourself.md
@@ -3,5 +3,3 @@
 
 At all times, be kind to each other and be mindful of other people's worries. [You may be in a low risk group and feel this is nothing to
 fret about, but your 80-year old neighbor or your friend with recent heart surgery may feel quite differently.](https://twitter.com/kakape/status/1235318985429782532) Every person matters; no one is "expendable."
-
-[With all the cancellations this is one of the first times I've seen normalization of an "it's everybody's problem approach." Yes, your one cancelled event might not save lives but the fact that everyone is doing this will. Same mentality is needed for climate change.](https://twitter.com/JasonWilliamsNY/status/1236332192172838912) Because travel is a big source of the spread, use the occasion to buy locally grown produce. This will reduce coronavirus transmission, support your local economy, and also have a net carbon savings.


### PR DESCRIPTION
Buying local may be beneficial for various reasons, but this paragraph seems poorly supported and less useful to the audience:

- It is not clear how buying locally will reduce Covid-19 transmission.
- Supporting the local economy is intuitive, but referencing evidence would make this point stronger anyway.
- It seems there is some debate about the effect of buying local on carbon footprint. For example, see [You want to reduce the carbon footprint of your food? Focus on what you eat, not whether your food is local](https://ourworldindata.org/food-choice-vs-eating-local) by Hannah Ritchie.

Maybe rewrite this with more evidence for each claim, if desired. However it also seems to me that this paragraph is less helpful to readers who are trying to learn how to survive Covid-19 and help reduce its impact.