### PR TITLE
Translate other pages

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -13,6 +13,8 @@ gem "jekyll", "~> 3.8.5"
 # This is the default theme for new Jekyll sites. You may change this to anything you like.
 gem "minima", "~> 2.0"
 
+gem "metadown", "~> 1.0.0"
+
 # If you want to use GitHub Pages, remove the "gem "jekyll"" above and
 # uncomment the line below. To upgrade, run `bundle update github-pages`.
 # gem "github-pages", group: :jekyll_plugins

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -51,6 +51,8 @@ GEM
       rb-fsevent (~> 0.10, >= 0.10.3)
       rb-inotify (~> 0.9, >= 0.9.10)
     mercenary (0.3.6)
+    metadown (1.0.1)
+      redcarpet
     mini_portile2 (2.4.0)
     minima (2.5.1)
       jekyll (>= 3.5, < 5.0)
@@ -65,6 +67,7 @@ GEM
     rb-fsevent (0.10.3)
     rb-inotify (0.10.1)
       ffi (~> 1.0)
+    redcarpet (3.5.0)
     rouge (3.17.0)
     ruby-lokalise-api (2.10.0)
       addressable (~> 2.5)
@@ -88,6 +91,7 @@ DEPENDENCIES
   jekyll-polyglot
   jekyll-toc
   jekyll-twitter-plugin
+  metadown (~> 1.0.0)
   minima (~> 2.0)
   ruby-lokalise-api
   rubyzip

--- a/_plugins/common.rb
+++ b/_plugins/common.rb
@@ -12,3 +12,12 @@ def key_from_page_filename(name)
     return $1
   end
 end
+
+def key_from_top_level_file(name)
+  basename = File.basename(name)
+  if basename =~ /(.+)-(\w\w).md/
+    return $1
+  else
+    raise "#{basename} doesn't match the \"some-page-en.md\" name format (in #{name})"
+  end
+end

--- a/_plugins/common.rb
+++ b/_plugins/common.rb
@@ -21,3 +21,7 @@ def key_from_top_level_file(name)
     raise "#{basename} doesn't match the \"some-page-en.md\" name format (in #{name})"
   end
 end
+
+def content_without_frontmatter(content)
+  content.gsub /\A---(.|\n)*?---/, ''
+end

--- a/import_language.rb
+++ b/import_language.rb
@@ -18,6 +18,11 @@ Dir["#{SOURCE_DIR}/**/*.md"].sort!.each { |filename|
   SECTIONS_TO_FILES[key_from_filename(filename)] = filename
 }
 
+TOP_LEVEL_PAGES = {}
+Dir["*-en.md"].sort!.each { |filename|
+  TOP_LEVEL_PAGES[key_from_top_level_file(filename)] = filename
+}
+
 def generate_content(translations_lang, translations_file)
   translations = JSON.parse(File.open(translations_file, 'r:UTF-8') { |f| f.read })
 
@@ -29,6 +34,17 @@ def generate_content(translations_lang, translations_file)
     FileUtils.mkdir_p(translated_dir)
     File.open(translated_file, "w:UTF-8") { |file|
       file.puts translations[section]
+    }
+  end
+
+  TOP_LEVEL_PAGES.each do |page, source_file|
+    puts "source_file: #{source_file}"
+    puts "page: #{page}"
+    puts "tranlsations_lang: #{translations_lang}"
+    translated_file = source_file.sub(/-en.md$/, "-#{translations_lang}.md")
+    puts "Translated_file: #{translated_file}"
+    File.open(translated_file, "w:UTF-8") { |file|
+      file.puts translations[page]
     }
   end
 end

--- a/import_language.rb
+++ b/import_language.rb
@@ -4,6 +4,7 @@ require 'fileutils'
 require 'ruby-lokalise-api'
 require 'open-uri'
 require 'zip'
+require 'metadown'
 require_relative '_plugins/common'
 
 def language_dir(lang)
@@ -41,9 +42,13 @@ def generate_content(translations_lang, translations_file)
     puts "source_file: #{source_file}"
     puts "page: #{page}"
     puts "tranlsations_lang: #{translations_lang}"
+    metadata = Metadown.render(File.open(source_file, 'r:UTF-8') { |f| f.read }).metadata
+    metadata["lang"] = translations_lang
     translated_file = source_file.sub(/-en.md$/, "-#{translations_lang}.md")
     puts "Translated_file: #{translated_file}"
     File.open(translated_file, "w:UTF-8") { |file|
+      file.puts metadata.to_yaml
+      file.puts "---\n" # Not sure why `#to_yaml` doesn't output the separator at the end
       file.puts translations[page]
     }
   end

--- a/import_language.rb
+++ b/import_language.rb
@@ -44,6 +44,7 @@ def generate_content(translations_lang, translations_file)
     puts "tranlsations_lang: #{translations_lang}"
     metadata = Metadown.render(File.open(source_file, 'r:UTF-8') { |f| f.read }).metadata
     metadata["lang"] = translations_lang
+    metadata["title"] = translations["#{page}-title"] if translations["#{page}-title"]
     translated_file = source_file.sub(/-en.md$/, "-#{translations_lang}.md")
     puts "Translated_file: #{translated_file}"
     File.open(translated_file, "w:UTF-8") { |file|

--- a/import_language.rb
+++ b/import_language.rb
@@ -40,17 +40,15 @@ def generate_content(translations_lang, translations_file)
 
   TOP_LEVEL_PAGES.each do |page, source_file|
     puts "source_file: #{source_file}"
-    puts "page: #{page}"
-    puts "tranlsations_lang: #{translations_lang}"
-    metadata = Metadown.render(File.open(source_file, 'r:UTF-8') { |f| f.read }).metadata
+    source_content = File.open(source_file, 'r:UTF-8') { |f| f.read }
+    metadata = Metadown.render(source_content).metadata
     metadata["lang"] = translations_lang
     metadata["title"] = translations["#{page}-title"] if translations["#{page}-title"]
     translated_file = source_file.sub(/-en.md$/, "-#{translations_lang}.md")
-    puts "Translated_file: #{translated_file}"
     File.open(translated_file, "w:UTF-8") { |file|
       file.puts metadata.to_yaml
-      file.puts "---\n" # Not sure why `#to_yaml` doesn't output the separator at the end
-      file.puts translations[page]
+      file.puts "---\n"
+      file.puts metadata["translate_content"] == false ? content_without_frontmatter(source_content) : translations[page]
     }
   end
 end


### PR DESCRIPTION
Allow to import from Lokalise the translations of pages other than the index.

It still doesn't support translating those pages titles, but we're going that way.