### PR TITLE
Fix the link in contacts

### DIFF
--- a/contact-en.md
+++ b/contact-en.md
@@ -8,7 +8,7 @@ order: 5
 
 You can follow <a href="https://www.twitter.com/flattencurve">@FlattenCurve</a> on Twitter for announcements of updates to the site.
 
-If you’re an expert and would like to contribute to the site (ANY relevant content is welcome), please check the [how to contribute](https://github.com/flattenthecurve/guide#how-to-contribute) guide.
+If you’re an expert and would like to contribute to the site (ANY relevant content is welcome), please check the [how to contribute](https://github.com/flattenthecurve/guide/blob/master/CONTRIBUTING.md#how-to-contribute) guide.
 
 If none of the options there work for you, you can email [hello@flattenthecurve.com](mailto:hello@flattenthecurve.com), but please be aware response times will be slow.
 


### PR DESCRIPTION
The original link did not lead anywhere. The other option would be to simply refer to /contribute page on the site itself which has variety of options how people can contribute.