### PR TITLE
Fixed table breaking layout on small screens

### DIFF
--- a/_sections/act_and_prepare/en/02-do/17-monitor-symptoms.md
+++ b/_sections/act_and_prepare/en/02-do/17-monitor-symptoms.md
@@ -7,13 +7,13 @@
 Compiled from [this WHO report](https://www.who.int/docs/default-source/coronaviruse/who-china-joint-mission-on-covid-19-final-report.pdf)   
 Common symtoms
 
-
+<div class="table-wrap" markdown="1">
 | symptom   | percentage | symptom         | percentage | symptom               | percentage |
 | ----------| ---------- | ----------------| ---------- | --------------------  | ---------- |
 | Fever     | 88%        |Fatigue          |38%         |Shortness of breath    |18%         |
 | Dry cough |68%         |Phlegm production|33.4%       |Sore throat            |14%         |
 |Headaches  |14%         |Muscle aches     |14%         |Chills                 |11%         |
-
+</div>
 
 **Only go to hospital when you have trouble breathing or you are short of breath (sitting, going to bathroom, walking, etc).**
 


### PR DESCRIPTION
Tables need to be wrapped in a `.table-wrap` div to prevent them from causing horizontal scrolling when they are wider than the page.

**BEFORE:**
<img width="397" alt="Screen Shot 2020-04-04 at 1 54 22 PM" src="https://user-images.githubusercontent.com/1728139/78461214-ee57ae00-767b-11ea-9b1c-0bd8aa20bff0.png">

**AFTER:**
<img width="399" alt="Screen Shot 2020-04-04 at 1 54 00 PM" src="https://user-images.githubusercontent.com/1728139/78461210-e4ce4600-767b-11ea-8c2a-c2ea4921706b.png">

