### PR TITLE
Fix language attribute on homepage

### DIFF
--- a/_includes/doc-top.html
+++ b/_includes/doc-top.html
@@ -1,0 +1,2 @@
+<!DOCTYPE html>
+<html lang="{{ page.lang | default: site.lang | default: 'en' }}">

--- a/_includes/lang-bar.html
+++ b/_includes/lang-bar.html
@@ -1,0 +1,4 @@
+<ul id="lang-bar" class="wrapper">
+{% for tongue in site.languages %}
+<li><a {% if tongue == site.active_lang %}style="font-weight: bold;"{% endif %} href="{% if tongue == site.default_lang %} {{site.baseurl}}{{page.url}} {% else %} {{site.baseurl}}/{{ tongue }}{{page.url}} {% endif %}">{{ site.data.lang_name[tongue] }}</a></li>{% endfor %}
+</ul>

--- a/_layouts/default.html
+++ b/_layouts/default.html
@@ -1,5 +1,4 @@
-<!DOCTYPE html>
-<html lang="{{ page.lang | default: site.lang | default: 'en' }}">
+{%- include doc-top.html -%}
 
 {%- include head.html -%}
 
@@ -7,10 +6,7 @@
 
   {%- include header.html -%}
 
-  <ul id="lang-bar" class="wrapper">
-    {% for tongue in site.languages %}
-    <li><a {% if tongue == site.active_lang %}style="font-weight: bold;"{% endif %} href="{% if tongue == site.default_lang %} {{site.baseurl}}{{page.url}} {% else %} {{site.baseurl}}/{{ tongue }}{{page.url}} {% endif %}">{{ site.data.lang_name[tongue] }}</a></li>{% endfor %}
-  </ul>
+  {%- include lang-bar.html -%}
 
   <main class="page-content" aria-label="Content">
     <div class="wrapper">

--- a/_layouts/home.html
+++ b/_layouts/home.html
@@ -1,34 +1,21 @@
----
-layout: default
----
+{%- include doc-top.html -%}
 
-  <div class="main">
-    {%- if page.title -%}
-    <h1 class="page-heading">{{ page.title }}</h1>
-    {%- endif -%}
+{%- include head.html -%}
 
-    {{ content }}
+<body class="home">
 
-    {%- if site.posts.size > 0 -%}
-    <h2 class="post-list-heading">{{ page.list_title | default: "Posts" }}</h2>
-    <ul class="post-list">
-      {%- for post in site.posts -%}
-      <li>
-        {%- assign date_format = site.minima.date_format | default: "%b %-d, %Y" -%}
-        <span class="post-meta">{{ post.date | date: date_format }}</span>
-        <h3>
-          <a class="post-link" href="{{ post.url | relative_url }}">
-            {{ post.title | escape }}
-          </a>
-        </h3>
-        {%- if site.show_excerpts -%}
-        {{ post.excerpt }}
-        {%- endif -%}
-      </li>
-      {%- endfor -%}
-    </ul>
+  {%- include header.html -%}
 
-    <p class="rss-subscribe">subscribe <a href="{{ "/feed.xml" | relative_url }}">via RSS</a></p>
-    {%- endif -%}
-  </div>
-</div>
+  {%- include lang-bar.html -%}
+
+  <main class="page-content" aria-label="Content">
+    <div class="wrapper">
+      {{ content }}
+    </div>
+  </main>
+
+  {%- include footer.html -%}
+
+</body>
+
+</html>

--- a/index-cs.md
+++ b/index-cs.md
@@ -1,0 +1,9 @@
+---
+layout: home
+title: Narovnejte křivku
+lang: cs
+permalink: /
+translate_content: false
+---
+
+{% render_section home %}

--- a/index-de.md
+++ b/index-de.md
@@ -1,0 +1,9 @@
+---
+layout: home
+title: Flache Kurve
+lang: de
+permalink: /
+translate_content: false
+---
+
+{% render_section home %}

--- a/index-el.md
+++ b/index-el.md
@@ -1,0 +1,9 @@
+---
+layout: home
+title: Ισοπέδωσε την καμπύλη
+lang: el
+permalink: /
+translate_content: false
+---
+
+{% render_section home %}

--- a/index-en.md
+++ b/index-en.md
@@ -1,0 +1,9 @@
+---
+layout: home
+title: Flatten the Curve
+lang: en
+permalink: /
+translate_content: false
+---
+
+{% render_section home %}

--- a/index-es.md
+++ b/index-es.md
@@ -1,0 +1,10 @@
+---
+layout: home
+title: Aplana La Curva
+lang: es
+permalink: /
+translate_content: false
+---
+
+
+{% render_section home %}

--- a/index-fr.md
+++ b/index-fr.md
@@ -1,0 +1,9 @@
+---
+layout: home
+title: Aplatir la Courbe
+lang: fr
+permalink: /
+translate_content: false
+---
+
+{% render_section home %}

--- a/index-it.md
+++ b/index-it.md
@@ -1,0 +1,9 @@
+---
+layout: home
+title: Appiattire la curva
+lang: it
+permalink: /
+translate_content: false
+---
+
+{% render_section home %}

--- a/index-ru.md
+++ b/index-ru.md
@@ -1,0 +1,9 @@
+---
+layout: home
+title: Сгладить кривую
+lang: ru
+permalink: /
+translate_content: false
+---
+
+{% render_section home %}

--- a/index.md
+++ b/index.md
@@ -1,9 +1,0 @@
----
-# Feel free to add content and custom Front Matter to this file.
-# To modify the layout, see https://jekyllrb.com/docs/themes/#overriding-theme-defaults
-
-layout: home
-translate_content: false
----
-
-{% render_section home %}


### PR DESCRIPTION
Closes #284 

This was originally reported as an issue with Greek, but it turns out this was actually an issue for all the languages besides English. Thanks to good research by @mpitid the root cause was that the hompage layout was not set up in a way that the `lang` attribute was being set correctly.

This should be reviewed by someone familiar with the localization infrastructure before merging...

### Before
<img width="1627" alt="Screen Shot 2020-04-04 at 5 27 08 PM" src="https://user-images.githubusercontent.com/1728139/78464169-c9befe80-769a-11ea-9573-036873595bab.png">

### After
<img width="1627" alt="Screen Shot 2020-04-04 at 5 27 31 PM" src="https://user-images.githubusercontent.com/1728139/78464176-cf1c4900-769a-11ea-82d9-b87e2063a170.png">