### PR TITLE
Resource script improvements

### DIFF
--- a/_scripts/import_resources.py
+++ b/_scripts/import_resources.py
@@ -6,6 +6,7 @@ import io
 import os
 import re
 import requests
+import yaml
 
 # Resource spreadsheet contents are published at this URL in the form of CSV
 RESOURCES_URL="https://docs.google.com/spreadsheets/d/e/2PACX-1vQMEdZXKgYNybkqNv4X26CVNoQZHuE0zb27wuBDgdDwtiyWCICQLhyU_LuLJVeHD5oTRnp-bEdFTuqi/pub?gid=650653420&single=true&output=csv"
@@ -46,20 +47,11 @@ def make_row_filename(row):
    
 def format_row_contents(row):
     """Generate MD output for each row."""
-    attr_rows = []
-    for attr in EXTRACT_ATTRIBUTES:
-        if not row.get(attr, None):
-            continue
-        # TODO: ensure special character escaping.
-        attr_rows.append(f'{attr}: {row[attr].strip()}')
-    all_attributes = '\n'.join(attr_rows)
-    return (
-        f"---\n"
-        f"{all_attributes}\n"
-        f"\nURL: {row['url'].strip()}\n"
-        f"---\n"
-        f"\n"
-        f"{row['description'].strip()}")
+    attributes = dict(
+        (attr, row[attr].strip()) for attr in EXTRACT_ATTRIBUTES if attr in row)
+    attributes['URL'] = row['url'].strip()
+    all_attributes = yaml.dump(attributes)
+    return (f"---\n{all_attributes}\n---\n\n{row['description'].strip()}")
 
 
 def get_resource_dir():

--- a/_scripts/import_resources.py
+++ b/_scripts/import_resources.py
@@ -11,7 +11,10 @@ import requests
 RESOURCES_URL="https://docs.google.com/spreadsheets/d/e/2PACX-1vQMEdZXKgYNybkqNv4X26CVNoQZHuE0zb27wuBDgdDwtiyWCICQLhyU_LuLJVeHD5oTRnp-bEdFTuqi/pub?gid=650653420&single=true&output=csv"
 
 parser = argparse.ArgumentParser(description='Parse arguments for this script.')
-parser.add_argument('--dryrun', '-n', default=False, action="store_true")
+parser.add_argument('--dryrun', '-n', default=False, action="store_true",
+                    help='Only print out what would be done.')
+parser.add_argument('--clobber', default=False, action="store_true",
+                    help='Overwrite existing resource files.')
 args = parser.parse_args()
 """Commandline argument values are stored here."""
 
@@ -88,18 +91,22 @@ def main():
         if not has_required:
             continue
 
+        filename = os.path.join(resource_dir, make_row_filename(row))
+        if os.path.isfile(filename) and not args.clobber:
+            print(f"Resource file {filename} already exists, skipping.")
+            continue
+
         rows_accepted += 1
-        filename = f'{resource_dir}{make_row_filename(row)}'
-        
         if args.dryrun:
             print(f"*** Dry run *** {filename} would contain:")
             print(format_row_contents(row))
-        else:
-            with open(filename, encoding='utf-8', mode='w+') as out_file:
-                out_file.write(format_row_contents(row))
-                out_file.close()
+            continue
 
-    print(f'Imported {rows_accepted} resources.')
+        with open(filename, encoding='utf-8', mode='w+') as out_file:
+            out_file.write(format_row_contents(row))
+            out_file.close()
+
+    print(f'(Re)generated {rows_accepted} resource files.')
         
 
 if __name__ == '__main__':

--- a/_scripts/import_resources.py
+++ b/_scripts/import_resources.py
@@ -22,7 +22,7 @@ args = parser.parse_args()
 REQUIRED_COLUMNS = ['name', 'category', 'description']
 """These columns must be non-empty for the row to be accepted."""
 
-EXTRACT_ATTRIBUTES = ['name', 'category', 'country', 'state']
+EXTRACT_ATTRIBUTES = ['name', 'category', 'country', 'state', 'url']
 """Columns that will be added into MD file as attributes, in this order."""
 
 
@@ -47,9 +47,10 @@ def make_row_filename(row):
    
 def format_row_contents(row):
     """Generate MD output for each row."""
-    attributes = dict(
-        (attr, row[attr].strip()) for attr in EXTRACT_ATTRIBUTES if attr in row)
-    attributes['URL'] = row['url'].strip()
+    attributes = {}
+    for attr in EXTRACT_ATTRIBUTES:
+        if row.get(attr, None):
+            attributes[attr] = row[attr].strip()
     all_attributes = yaml.dump(attributes)
     return (f"---\n{all_attributes}\n---\n\n{row['description'].strip()}")
 


### PR DESCRIPTION
Few improvements to the resource import process.

1. use yaml.dump to properly escape the attributes for each resource
2. use lowercase url so that it is consistent with the column name and doesn't need special treatment (subsequent change to resources.md and regen of existing resource will be part of a separate PR)
3. Added --clobber flag that skips over already existing resource files by default