### PR TITLE
Fixes to the resource page

### DIFF
--- a/_resources/2020-03-21-safe-handling-and-decontamination.md
+++ b/_resources/2020-03-21-safe-handling-and-decontamination.md
@@ -1,8 +1,8 @@
 ---
-name: Safe handling and decontamination
 category: Educational content
+name: Safe handling and decontamination
+url: https://drive.google.com/file/d/1M9_VTMJpP5Jo-NxI_ac7TUtpoAvJHSVs/view
 
-URL: https://drive.google.com/file/d/1M9_VTMJpP5Jo-NxI_ac7TUtpoAvJHSVs/view
 ---
 
 Guidelines for receiving food, clothes, deliveries and coming inside.

--- a/_resources/2020-03-22-covid-tracking-project.md
+++ b/_resources/2020-03-22-covid-tracking-project.md
@@ -1,9 +1,9 @@
 ---
-name: COVID Tracking Project
 category: Chart, visualization, infographic
 country: USA
+name: COVID Tracking Project
+url: https://covidtracking.com/
 
-URL: https://covidtracking.com/
 ---
 
 The COVID Tracking Project collects information from 50 US states, the District of Columbia, and 5 other US territories to provide the most comprehensive testing data.

--- a/_resources/2020-03-22-official-covid-19-nj-info-hub.md
+++ b/_resources/2020-03-22-official-covid-19-nj-info-hub.md
@@ -1,10 +1,10 @@
 ---
-name: Official Covid-19 NJ Info Hub
 category: gov
 country: USA
+name: Official Covid-19 NJ Info Hub
 state: New Jersey
+url: https://covid19.nj.gov/
 
-URL: https://covid19.nj.gov/
 ---
 
 This hub page for NJ keeps track of all new cases separated by counties, latest orders signed by the governor and what residents and businesses should do to keep safe.

--- a/_resources/2020-03-23-covid-19-collective-care.md
+++ b/_resources/2020-03-23-covid-19-collective-care.md
@@ -1,9 +1,9 @@
 ---
-name: COVID-19 Collective Care
 category: community-sourced mutual aid links for different locations
 country: USA
+name: COVID-19 Collective Care
+url: https://docs.google.com/document/d/1dpMzMzsA83jbVEXS8m7QKOtK4nj6gIUk1U1t6P4wShY/edit
 
-URL: https://docs.google.com/document/d/1dpMzMzsA83jbVEXS8m7QKOtK4nj6gIUk1U1t6P4wShY/edit
 ---
 
 general resources & mutual aid groups

--- a/_resources/2020-03-23-covid-19-resources-for-students.md
+++ b/_resources/2020-03-23-covid-19-resources-for-students.md
@@ -1,9 +1,9 @@
 ---
-name: COVID-19 Resources for Students
 category: community sourced mutual aid links
 country: USA
+name: COVID-19 Resources for Students
+url: https://docs.google.com/document/d/1JEwYeYeqhe0xCUSHZHV0ZKeUwxqVCQlcDq-pM-0a9YU/edit
 
-URL: https://docs.google.com/document/d/1JEwYeYeqhe0xCUSHZHV0ZKeUwxqVCQlcDq-pM-0a9YU/edit
 ---
 
 COVID-19 Resources for Students

--- a/_resources/2020-03-23-covid-19-tracking-and-projections.md
+++ b/_resources/2020-03-23-covid-19-tracking-and-projections.md
@@ -1,9 +1,9 @@
 ---
-name: COVID-19 Tracking and Projections
 category: Web Application
 country: Global
+name: COVID-19 Tracking and Projections
+url: https://flattenthecurve.co.nz
 
-URL: https://flattenthecurve.co.nz
 ---
 
 Allowing non technical users to compare their country with other situations around the world. We present configurable cumulative graph curves. We compare your countries current status with other countries who have already been at your level and show you where they've ended up. We are working on extending the comparison to work for regions within one country. The data is provided via JHU.

--- a/_resources/2020-03-23-loss-of-sense-of-smell-as-marker-of.md
+++ b/_resources/2020-03-23-loss-of-sense-of-smell-as-marker-of.md
@@ -1,8 +1,8 @@
 ---
-name: Loss of sense of smell as marker of COVID-19 infection
 category: Educational content
+name: Loss of sense of smell as marker of COVID-19 infection
+url: https://www.entuk.org/loss-sense-smell-marker-covid-19-infection
 
-URL: https://www.entuk.org/loss-sense-smell-marker-covid-19-infection
 ---
 
 The professional membership body representing Ear, Nose and Throat surgery in the UK is suggesting loss of smell without other symptoms may be a sign of mild COVID-19 infection.

--- a/_resources/2020-03-23-us-covid-19-mutual-aid-resources.md
+++ b/_resources/2020-03-23-us-covid-19-mutual-aid-resources.md
@@ -1,9 +1,9 @@
 ---
-name: US COVID-19 Mutual Aid Resources
 category: community sourced mutual aid links
 country: USA
+name: US COVID-19 Mutual Aid Resources
+url: https://drive.google.com/drive/folders/1dKDM8CA32gZ1L2v_MFewohqJhVnCsi71?usp=sharing
 
-URL: https://drive.google.com/drive/folders/1dKDM8CA32gZ1L2v_MFewohqJhVnCsi71?usp=sharing
 ---
 
 Google folders by state

--- a/_resources/2020-03-24-covid-19-open-source-helpdesk.md
+++ b/_resources/2020-03-24-covid-19-open-source-helpdesk.md
@@ -1,8 +1,8 @@
 ---
-name: COVID-19 Open-Source Helpdesk
 category: Open software support
+name: COVID-19 Open-Source Helpdesk
+url: https://discourse.covid-oss-help.org/
 
-URL: https://discourse.covid-oss-help.org/
 ---
 
 This place is for domain experts fighting COVID-19 who make use of open-source software in their work. Ask questions to get help from the authors and maintainers of the main packages open-source scientific computing stack, so that you don’t block on issues that we could fix easily.

--- a/_resources/2020-03-24-data-against-covid-19.md
+++ b/_resources/2020-03-24-data-against-covid-19.md
@@ -1,8 +1,8 @@
 ---
-name: Data Against COVID-19
 category: Data Science support
+name: Data Against COVID-19
+url: https://www.data-against-covid.org/
 
-URL: https://www.data-against-covid.org/
 ---
 
 You – clinicians, virologists, immunologists – are working around the clock to combat the epidemic. We – machine learners, bioinformaticians, epidemiologists, statisticians – are eager to help. This is the place to post your data and give us tasks: answer your questions, analyze your data, make predictions. Just remember that to help you, we need data. If you’re unsure where to begin,

--- a/_resources/2020-03-25-corona-virus-full-fact-news-checkin.md
+++ b/_resources/2020-03-25-corona-virus-full-fact-news-checkin.md
@@ -1,8 +1,8 @@
 ---
-name: Corona Virus - Full Fact - News checking organisation
 category: Educational content
+name: Corona Virus - Full Fact - News checking organisation
+url: https://fullfact.org/health/coronavirus/?utm_source=homepage&utm_medium=trending
 
-URL: https://fullfact.org/health/coronavirus/?utm_source=homepage&utm_medium=trending
 ---
 
 Full Fact fights bad information.

--- a/_resources/2020-03-27-coronavirus-the-science-explained.md
+++ b/_resources/2020-03-27-coronavirus-the-science-explained.md
@@ -1,8 +1,8 @@
 ---
-name: Coronavirus: the science explained
 category: Scientific publication
+name: 'Coronavirus: the science explained'
+url: https://coronavirusexplained.ukri.org/en/
 
-URL: https://coronavirusexplained.ukri.org/en/
 ---
 
 Coronavirus: the science explained lays out the evidence and the facts about the virus, the disease, the epidemic, and its control.

--- a/_resources/2020-03-27-covid-19-research-search-engine.md
+++ b/_resources/2020-03-27-covid-19-research-search-engine.md
@@ -1,8 +1,8 @@
 ---
-name: COVID-19 Research Search Engine
 category: Scientific publication
+name: COVID-19 Research Search Engine
+url: https://covidsmartsearch.recital.ai
 
-URL: https://covidsmartsearch.recital.ai
 ---
 
 As of March 23, our COVID-19 research database contains 1255 articles (and counting) within the 2380 references selected by the WHO in its Global Research on COVID-19 list.

--- a/_resources/2020-03-27-why-you-must-act-now-by-state.md
+++ b/_resources/2020-03-27-why-you-must-act-now-by-state.md
@@ -1,9 +1,9 @@
 ---
-name: Why you must act now - By State
 category: Model or Simulation
 country: USA
+name: Why you must act now - By State
+url: https://covidactnow.org
 
-URL: https://covidactnow.org
 ---
 
 CovidActNow.org was created by a team of data scientists, engineers, and designers in partnership with epidemiologists, public health officials, and political leaders to help understand how the COVID-19 pandemic will affect their region.

--- a/_resources/2020-03-28-covid-19-spread-vs-healthcare-capac.md
+++ b/_resources/2020-03-28-covid-19-spread-vs-healthcare-capac.md
@@ -1,8 +1,8 @@
 ---
-name: COVID-19 Spread vs Healthcare Capacity
 category: model
+name: COVID-19 Spread vs Healthcare Capacity
+url: https://alhill.shinyapps.io/COVID19seir/
 
-URL: https://alhill.shinyapps.io/COVID19seir/
 ---
 
 Modeling COVID-19 Spread vs Healthcare Capacity

--- a/_resources/2020-03-28-covid19-day-by-day.md
+++ b/_resources/2020-03-28-covid19-day-by-day.md
@@ -1,8 +1,8 @@
 ---
-name: Covid19 day by day
 category: Educational content
+name: Covid19 day by day
+url: https://www.businessinsider.com/novel-coronavirus-covid-19-symptoms-day-by-day-2020-3
 
-URL: https://www.businessinsider.com/novel-coronavirus-covid-19-symptoms-day-by-day-2020-3
 ---
 
 Symptoms of covid19 day by day. 

--- a/_resources/2020-03-28-epidemic-calculator.md
+++ b/_resources/2020-03-28-epidemic-calculator.md
@@ -1,8 +1,8 @@
 ---
-name: Epidemic Calculator
 category: model
+name: Epidemic Calculator
+url: http://gabgoh.github.io/COVID/index.html
 
-URL: http://gabgoh.github.io/COVID/index.html
 ---
 
 This calculator implements a classical infectious disease model — SEIR (Susceptible -> Exposed -> Infected -> Removed), an idealized model of spread still used in frontlines of research

--- a/_resources/2020-03-28-ministerio-de-salud-de-la-nacin.md
+++ b/_resources/2020-03-28-ministerio-de-salud-de-la-nacin.md
@@ -1,9 +1,9 @@
 ---
-name: Ministerio de Salud de la Nación
 category: gov
 country: Argentina
+name: "Ministerio de Salud de la Naci\xF3n"
+url: https://www.argentina.gob.ar/salud/coronavirus-COVID-19
 
-URL: https://www.argentina.gob.ar/salud/coronavirus-COVID-19
 ---
 
 Información, recomendaciones del Ministerio de Salud de la Nación y medidas de prevención.

--- a/_resources/2020-03-28-world-health-organization.md
+++ b/_resources/2020-03-28-world-health-organization.md
@@ -1,8 +1,8 @@
 ---
-name: World Health Organization
 category: gov
+name: World Health Organization
+url: https://www.who.int/health-topics/coronavirus
 
-URL: https://www.who.int/health-topics/coronavirus
 ---
 
 World Heath Organization information on Coronavirus disease (COVID-19) Pandemic

--- a/_resources/2020-03-29-coronavirus-disease-covid-19-statis.md
+++ b/_resources/2020-03-29-coronavirus-disease-covid-19-statis.md
@@ -1,8 +1,8 @@
 ---
-name: Coronavirus Disease (COVID-19) – Statistics and Research
 category: Chart, visualization, infographic
+name: "Coronavirus Disease (COVID-19) \u2013 Statistics and Research"
+url: https://ourworldindata.org/coronavirus
 
-URL: https://ourworldindata.org/coronavirus
 ---
 
 "We present information on the number of deaths and cases; on why we should focus on how quickly those numbers double, not on the numbers themselves; on the prevalence of testing, and why that is important for understanding the disease; and what we can and can’t know about how lethal COVID-19 really is. We’ll also explain where we get our data from and why."

--- a/_resources/2020-04-03-brief-video-explaining-why-flatteni.md
+++ b/_resources/2020-04-03-brief-video-explaining-why-flatteni.md
@@ -1,8 +1,8 @@
 ---
-name: Brief video explaining why flattening the curve is important
 category: Educational content
+name: Brief video explaining why flattening the curve is important
+url: https://www.youtube.com/watch?v=fgBla7RepXU
 
-URL: https://www.youtube.com/watch?v=fgBla7RepXU
 ---
 
 Very nice video for lay people explaining exponential growth & #FlattenTheCurve concepts

--- a/_resources/2020-04-03-co-mask.md
+++ b/_resources/2020-04-03-co-mask.md
@@ -1,8 +1,8 @@
 ---
-name: Co-MASK
 category: Educational content
+name: Co-MASK
+url: https://co-mask.github.io/
 
-URL: https://co-mask.github.io/
 ---
 
 We invite you to join a global project to create fabric masks that promote hope, humanity, and hygiene practices in time of crisis. Collaborating across borders, we want to raise awareness about the risks of COVID-19 infection and the need for physical distancing and self-isolation, while advocating solidarity with the most vulnerable in our global community.

--- a/_resources/2020-04-03-coronavirus-the-science-explained.md
+++ b/_resources/2020-04-03-coronavirus-the-science-explained.md
@@ -1,8 +1,8 @@
 ---
-name: Coronavirus: the science explained
 category: Educational content
+name: 'Coronavirus: the science explained'
+url: https://coronavirusexplained.ukri.org/
 
-URL: https://coronavirusexplained.ukri.org/
 ---
 
 Coronavirus: the science explained' lays out the evidence and the facts about the virus, the disease, the epidemic, and its control; regularly updated with the latest science information behind the coronavirus outbreak.

--- a/_resources/2020-04-03-makermask.md
+++ b/_resources/2020-04-03-makermask.md
@@ -1,8 +1,8 @@
 ---
-name: MakerMask
 category: Educational content
+name: MakerMask
+url: http://makermask.org/
 
-URL: http://makermask.org/
 ---
 
 MakerMask is a source for science-based mask designs for community makers to combat the spread of COVID-19. It is important that we use the best information possible to help protect ourselves and our communities. The MakerMask designs use latex-free, water-resistant materials that are likely to provide improved protection over cotton and elastic.  We need makers/sewists/helpers of all abilities to begin ramping up production to meet community needs.

--- a/_resources/2020-04-03-the-covid-tracking-project.md
+++ b/_resources/2020-04-03-the-covid-tracking-project.md
@@ -1,9 +1,9 @@
 ---
-name: The COVID Tracking Project
 category: Chart, visualization, infographic
 country: USA
+name: The COVID Tracking Project
+url: https://covidtracking.com/
 
-URL: https://covidtracking.com/
 ---
 
 The COVID Tracking Project collects and publishes the most complete testing data available for US states and territories.

--- a/_resources/2020-04-03-where-to-safely-shop-during-covid-1.md
+++ b/_resources/2020-04-03-where-to-safely-shop-during-covid-1.md
@@ -1,10 +1,10 @@
 ---
-name: Where to Safely Shop during Covid-19
 category: Educational content
-country: United States
+country: USA
+name: Where to Safely Shop during Covid-19
 state: MA
+url: http://helptofight.org/shopsafely
 
-URL: http://helptofight.org/shopsafely
 ---
 
 A group of Cambridge residents have come together to help people decide where they can safely shop. The goal is to encourage businesses to comply with containment policies to minimize the spread of Covid-19 virus in our community, and help keep their customers and employees safe. See best practices, and better yet, sign this petition to get more PPE to grocery stores.

--- a/_scripts/import_resources.py
+++ b/_scripts/import_resources.py
@@ -6,6 +6,7 @@ import io
 import os
 import re
 import requests
+import yaml
 
 # Resource spreadsheet contents are published at this URL in the form of CSV
 RESOURCES_URL="https://docs.google.com/spreadsheets/d/e/2PACX-1vQMEdZXKgYNybkqNv4X26CVNoQZHuE0zb27wuBDgdDwtiyWCICQLhyU_LuLJVeHD5oTRnp-bEdFTuqi/pub?gid=650653420&single=true&output=csv"
@@ -46,20 +47,11 @@ def make_row_filename(row):
    
 def format_row_contents(row):
     """Generate MD output for each row."""
-    attr_rows = []
-    for attr in EXTRACT_ATTRIBUTES:
-        if not row.get(attr, None):
-            continue
-        # TODO: ensure special character escaping.
-        attr_rows.append(f'{attr}: {row[attr].strip()}')
-    all_attributes = '\n'.join(attr_rows)
-    return (
-        f"---\n"
-        f"{all_attributes}\n"
-        f"\nURL: {row['url'].strip()}\n"
-        f"---\n"
-        f"\n"
-        f"{row['description'].strip()}")
+    attributes = dict(
+        (attr, row[attr].strip()) for attr in EXTRACT_ATTRIBUTES if attr in row)
+    attributes['URL'] = row['url'].strip()
+    all_attributes = yaml.dump(attributes)
+    return (f"---\n{all_attributes}\n---\n\n{row['description'].strip()}")
 
 
 def get_resource_dir():

--- a/_scripts/import_resources.py
+++ b/_scripts/import_resources.py
@@ -11,7 +11,10 @@ import requests
 RESOURCES_URL="https://docs.google.com/spreadsheets/d/e/2PACX-1vQMEdZXKgYNybkqNv4X26CVNoQZHuE0zb27wuBDgdDwtiyWCICQLhyU_LuLJVeHD5oTRnp-bEdFTuqi/pub?gid=650653420&single=true&output=csv"
 
 parser = argparse.ArgumentParser(description='Parse arguments for this script.')
-parser.add_argument('--dryrun', '-n', default=False, action="store_true")
+parser.add_argument('--dryrun', '-n', default=False, action="store_true",
+                    help='Only print out what would be done.')
+parser.add_argument('--clobber', default=False, action="store_true",
+                    help='Overwrite existing resource files.')
 args = parser.parse_args()
 """Commandline argument values are stored here."""
 
@@ -88,18 +91,22 @@ def main():
         if not has_required:
             continue
 
+        filename = os.path.join(resource_dir, make_row_filename(row))
+        if os.path.isfile(filename) and not args.clobber:
+            print(f"Resource file {filename} already exists, skipping.")
+            continue
+
         rows_accepted += 1
-        filename = f'{resource_dir}{make_row_filename(row)}'
-        
         if args.dryrun:
             print(f"*** Dry run *** {filename} would contain:")
             print(format_row_contents(row))
-        else:
-            with open(filename, encoding='utf-8', mode='w+') as out_file:
-                out_file.write(format_row_contents(row))
-                out_file.close()
+            continue
 
-    print(f'Imported {rows_accepted} resources.')
+        with open(filename, encoding='utf-8', mode='w+') as out_file:
+            out_file.write(format_row_contents(row))
+            out_file.close()
+
+    print(f'(Re)generated {rows_accepted} resource files.')
         
 
 if __name__ == '__main__':

--- a/_scripts/import_resources.py
+++ b/_scripts/import_resources.py
@@ -22,7 +22,7 @@ args = parser.parse_args()
 REQUIRED_COLUMNS = ['name', 'category', 'description']
 """These columns must be non-empty for the row to be accepted."""
 
-EXTRACT_ATTRIBUTES = ['name', 'category', 'country', 'state']
+EXTRACT_ATTRIBUTES = ['name', 'category', 'country', 'state', 'url']
 """Columns that will be added into MD file as attributes, in this order."""
 
 
@@ -47,9 +47,10 @@ def make_row_filename(row):
    
 def format_row_contents(row):
     """Generate MD output for each row."""
-    attributes = dict(
-        (attr, row[attr].strip()) for attr in EXTRACT_ATTRIBUTES if attr in row)
-    attributes['URL'] = row['url'].strip()
+    attributes = {}
+    for attr in EXTRACT_ATTRIBUTES:
+        if row.get(attr, None):
+            attributes[attr] = row[attr].strip()
     all_attributes = yaml.dump(attributes)
     return (f"---\n{all_attributes}\n---\n\n{row['description'].strip()}")
 

--- a/_scripts/import_resources.py
+++ b/_scripts/import_resources.py
@@ -6,23 +6,19 @@ import io
 import os
 import re
 import requests
-import yaml
 
 # Resource spreadsheet contents are published at this URL in the form of CSV
 RESOURCES_URL="https://docs.google.com/spreadsheets/d/e/2PACX-1vQMEdZXKgYNybkqNv4X26CVNoQZHuE0zb27wuBDgdDwtiyWCICQLhyU_LuLJVeHD5oTRnp-bEdFTuqi/pub?gid=650653420&single=true&output=csv"
 
 parser = argparse.ArgumentParser(description='Parse arguments for this script.')
-parser.add_argument('--dryrun', '-n', default=False, action="store_true",
-                    help='Only print out what would be done.')
-parser.add_argument('--clobber', default=False, action="store_true",
-                    help='Overwrite existing resource files.')
+parser.add_argument('--dryrun', '-n', default=False, action="store_true")
 args = parser.parse_args()
 """Commandline argument values are stored here."""
 
 REQUIRED_COLUMNS = ['name', 'category', 'description']
 """These columns must be non-empty for the row to be accepted."""
 
-EXTRACT_ATTRIBUTES = ['name', 'category', 'country', 'state', 'url']
+EXTRACT_ATTRIBUTES = ['name', 'category', 'country', 'state']
 """Columns that will be added into MD file as attributes, in this order."""
 
 
@@ -47,12 +43,20 @@ def make_row_filename(row):
    
 def format_row_contents(row):
     """Generate MD output for each row."""
-    attributes = {}
+    attr_rows = []
     for attr in EXTRACT_ATTRIBUTES:
-        if row.get(attr, None):
-            attributes[attr] = row[attr].strip()
-    all_attributes = yaml.dump(attributes)
-    return (f"---\n{all_attributes}\n---\n\n{row['description'].strip()}")
+        if not row.get(attr, None):
+            continue
+        # TODO: ensure special character escaping.
+        attr_rows.append(f'{attr}: {row[attr].strip()}')
+    all_attributes = '\n'.join(attr_rows)
+    return (
+        f"---\n"
+        f"{all_attributes}\n"
+        f"\nURL: {row['url'].strip()}\n"
+        f"---\n"
+        f"\n"
+        f"{row['description'].strip()}")
 
 
 def get_resource_dir():
@@ -84,22 +88,18 @@ def main():
         if not has_required:
             continue
 
-        filename = os.path.join(resource_dir, make_row_filename(row))
-        if os.path.isfile(filename) and not args.clobber:
-            print(f"Resource file {filename} already exists, skipping.")
-            continue
-
         rows_accepted += 1
+        filename = f'{resource_dir}{make_row_filename(row)}'
+        
         if args.dryrun:
             print(f"*** Dry run *** {filename} would contain:")
             print(format_row_contents(row))
-            continue
+        else:
+            with open(filename, encoding='utf-8', mode='w+') as out_file:
+                out_file.write(format_row_contents(row))
+                out_file.close()
 
-        with open(filename, encoding='utf-8', mode='w+') as out_file:
-            out_file.write(format_row_contents(row))
-            out_file.close()
-
-    print(f'(Re)generated {rows_accepted} resource files.')
+    print(f'Imported {rows_accepted} resources.')
         
 
 if __name__ == '__main__':

--- a/resources.md
+++ b/resources.md
@@ -25,7 +25,7 @@ If you want to contribute to this list, you can do it [here](https://forms.gle/2
     {% endif %}
   {% endif %}
 
-###  <a href="{{ resource.URL }}">{{ resource.name }}</a> 
+###  <a href="{{ resource.url }}">{{ resource.name }}</a>
   <p>{{ resource.content | markdownify }}</p>
   <hr/>
 {% endfor %}


### PR DESCRIPTION
This is a second part of https://github.com/flattenthecurve/guide/pull/305 (should be only integrated once the other PR is in).

This PR:
1. switches to lowercase url attribute for resources (to eliminate need for special treatments)
2. properly escapes all resource attributes & removes some ad-hoc empty lines in the resource files
3. Converts United States to USA in one of the resource files. [1]

[1] it might be worth creating automatic rule converting the country name to the canonical form when new resource submission is received.