### PR TITLE
Prettier resources

### DIFF
--- a/_layouts/legacy-home.html
+++ b/_layouts/legacy-home.html
@@ -1,0 +1,21 @@
+{%- include doc-top.html -%}
+
+{%- include head.html -%}
+
+<body class="legacy-homepage">
+
+  {%- include header.html -%}
+
+  {%- include lang-bar.html -%}
+
+  <main class="page-content" aria-label="Content">
+    <div class="wrapper">
+      {{ content }}
+    </div>
+  </main>
+
+  {%- include footer.html -%}
+
+</body>
+
+</html>

--- a/_resources/2020-04-03-where-to-safely-shop-during-covid-1.md
+++ b/_resources/2020-04-03-where-to-safely-shop-during-covid-1.md
@@ -1,7 +1,7 @@
 ---
 name: Where to Safely Shop during Covid-19
 category: Educational content
-country: United States
+country: USA
 state: MA
 
 URL: http://helptofight.org/shopsafely

--- a/_resources/2020-04-03-where-to-safely-shop-during-covid-1.md
+++ b/_resources/2020-04-03-where-to-safely-shop-during-covid-1.md
@@ -1,7 +1,7 @@
 ---
 name: Where to Safely Shop during Covid-19
 category: Educational content
-country: USA
+country: United States
 state: MA
 
 URL: http://helptofight.org/shopsafely

--- a/_sass/minima.scss
+++ b/_sass/minima.scss
@@ -96,14 +96,15 @@ $on-laptop:        1440px !default;
 
 // Import partials.
 @import
+  "minima/typography",
   "minima/base",
   "minima/layout",
   "minima/header",
   "minima/footer",
-  "minima/typography",
   "minima/act_prepare",
   "minima/posts",
   "minima/tables",
   "minima/home",
-  "minima/utilities"
+  "minima/utilities",
+  "minima/legacy-homepage"
 ;

--- a/_sass/minima/_base.scss
+++ b/_sass/minima/_base.scss
@@ -34,7 +34,7 @@ h1, h2, h3, h4, h5, h6,
 p, blockquote, pre,
 ul, ol, dl, figure,
 %vertical-rhythm {
-  margin-bottom: $spacing-unit / 2;
+  margin-bottom: .25em;
 }
 
 
@@ -97,10 +97,10 @@ li {
  */
 h1,
 .title {
-  font-weight: 'Helvetica Neue Bold Condensed';
-  font-size: 30px;
+  font-size: 2.5em;
   margin-top: 1em;
   text-transform: uppercase;
+  @include title-text;
 }
 
 h2,
@@ -116,6 +116,7 @@ h3,
   font-weight: normal;
   font-size: 1.333333em;
   font-style: italic;
+  margin-top: 1em;
 }
 
 .page-heading,

--- a/_sass/minima/_layout.scss
+++ b/_sass/minima/_layout.scss
@@ -8,15 +8,6 @@
 
 .page-content .wrapper {
   padding-bottom: 3em;
-
-  // This is to style non-english page title, until .hero is added
-  h1:first-of-type {
-    font-size: 45px;
-  }
-  // and this
-  h2:first-of-type {
-    margin-top: 0;
-  }
 }
 
 @include media-query($on-laptop) {

--- a/_sass/minima/_legacy-homepage.scss
+++ b/_sass/minima/_legacy-homepage.scss
@@ -1,0 +1,22 @@
+// This is the home for hacks that should only apply to the legacy homepage (still in place for non-English versions)
+// When the legacy homepage is no longer in use, this file should get removed.
+// You can check for this by checkig the /index-*.md files and looking for this:
+//
+// <div class="legacy-homepage" markdown="1">
+// {% render_section home %}
+// </div>
+//
+// When all those wrapping divs are gone, these styles are no longer relevant.
+.legacy-homepage {
+
+	.page-content .wrapper {
+		// This is to style non-english page title, until .hero is added
+		h1:first-of-type {
+			font-size: 45px;
+		}
+		// and this
+		h2:first-of-type {
+			margin-top: 0;
+		}
+	}
+}

--- a/index-cs.md
+++ b/index-cs.md
@@ -1,5 +1,5 @@
 ---
-layout: home
+layout: legacy-home
 title: Narovnejte křivku
 lang: cs
 permalink: /

--- a/index-de.md
+++ b/index-de.md
@@ -1,5 +1,5 @@
 ---
-layout: home
+layout: legacy-home
 title: Flache Kurve
 lang: de
 permalink: /

--- a/index-el.md
+++ b/index-el.md
@@ -1,5 +1,5 @@
 ---
-layout: home
+layout: legacy-home
 title: Ισοπέδωσε την καμπύλη
 lang: el
 permalink: /

--- a/index-es.md
+++ b/index-es.md
@@ -1,10 +1,9 @@
 ---
-layout: home
+layout: legacy-home
 title: Aplana La Curva
 lang: es
 permalink: /
 translate_content: false
 ---
-
 
 {% render_section home %}

--- a/index-fr.md
+++ b/index-fr.md
@@ -1,5 +1,5 @@
 ---
-layout: home
+layout: legacy-home
 title: Aplatir la Courbe
 lang: fr
 permalink: /

--- a/index-it.md
+++ b/index-it.md
@@ -1,5 +1,5 @@
 ---
-layout: home
+layout: legacy-home
 title: Appiattire la curva
 lang: it
 permalink: /

--- a/index-ru.md
+++ b/index-ru.md
@@ -1,5 +1,5 @@
 ---
-layout: home
+layout: legacy-home
 title: Сгладить кривую
 lang: ru
 permalink: /

--- a/resources.md
+++ b/resources.md
@@ -10,8 +10,6 @@ order: 2
 
 If you want to contribute to this list, you can do it [here](https://forms.gle/2zi67brmMZ7byCvb8)
 
-<hr/>
-
 {% assign current_country = "" %} 
 {% assign resources = site.resources | sort: 'country' %}
 {% for resource in resources %}
@@ -27,5 +25,4 @@ If you want to contribute to this list, you can do it [here](https://forms.gle/2
 
 ###  <a href="{{ resource.URL }}">{{ resource.name }}</a> 
   <p>{{ resource.content | markdownify }}</p>
-  <hr/>
 {% endfor %}


### PR DESCRIPTION
The Resources page was looking really cluttered...

* Cleaned up the template
* Cleaned up the CSS
* Re-implemented a hack for the legacy homepage (that was applying globally to the whole site)
* Fixed a resource that had "United States" instead of "USA"

### BEFORE
<img width="1381" alt="Screen Shot 2020-04-05 at 11 58 44 AM" src="https://user-images.githubusercontent.com/1728139/78507542-633aee80-7735-11ea-9e51-79618714715b.png">

### AFTER
<img width="1381" alt="Screen Shot 2020-04-05 at 11 58 27 AM" src="https://user-images.githubusercontent.com/1728139/78507548-6afa9300-7735-11ea-9086-9570a3ed4add.png">
