### PR TITLE
Fix resource hrefs by replacing url with target

### DIFF
--- a/_resources/2020-03-21-safe-handling-and-decontamination.md
+++ b/_resources/2020-03-21-safe-handling-and-decontamination.md
@@ -1,7 +1,7 @@
 ---
 category: Educational content
 name: Safe handling and decontamination
-url: https://drive.google.com/file/d/1M9_VTMJpP5Jo-NxI_ac7TUtpoAvJHSVs/view
+target: https://drive.google.com/file/d/1M9_VTMJpP5Jo-NxI_ac7TUtpoAvJHSVs/view
 
 ---
 

--- a/_resources/2020-03-22-covid-tracking-project.md
+++ b/_resources/2020-03-22-covid-tracking-project.md
@@ -2,7 +2,7 @@
 category: Chart, visualization, infographic
 country: USA
 name: COVID Tracking Project
-url: https://covidtracking.com/
+target: https://covidtracking.com/
 
 ---
 

--- a/_resources/2020-03-22-official-covid-19-nj-info-hub.md
+++ b/_resources/2020-03-22-official-covid-19-nj-info-hub.md
@@ -3,7 +3,7 @@ category: gov
 country: USA
 name: Official Covid-19 NJ Info Hub
 state: New Jersey
-url: https://covid19.nj.gov/
+target: https://covid19.nj.gov/
 
 ---
 

--- a/_resources/2020-03-23-covid-19-collective-care.md
+++ b/_resources/2020-03-23-covid-19-collective-care.md
@@ -2,7 +2,7 @@
 category: community-sourced mutual aid links for different locations
 country: USA
 name: COVID-19 Collective Care
-url: https://docs.google.com/document/d/1dpMzMzsA83jbVEXS8m7QKOtK4nj6gIUk1U1t6P4wShY/edit
+target: https://docs.google.com/document/d/1dpMzMzsA83jbVEXS8m7QKOtK4nj6gIUk1U1t6P4wShY/edit
 
 ---
 

--- a/_resources/2020-03-23-covid-19-resources-for-students.md
+++ b/_resources/2020-03-23-covid-19-resources-for-students.md
@@ -2,7 +2,7 @@
 category: community sourced mutual aid links
 country: USA
 name: COVID-19 Resources for Students
-url: https://docs.google.com/document/d/1JEwYeYeqhe0xCUSHZHV0ZKeUwxqVCQlcDq-pM-0a9YU/edit
+target: https://docs.google.com/document/d/1JEwYeYeqhe0xCUSHZHV0ZKeUwxqVCQlcDq-pM-0a9YU/edit
 
 ---
 

--- a/_resources/2020-03-23-covid-19-tracking-and-projections.md
+++ b/_resources/2020-03-23-covid-19-tracking-and-projections.md
@@ -2,7 +2,7 @@
 category: Web Application
 country: Global
 name: COVID-19 Tracking and Projections
-url: https://flattenthecurve.co.nz
+target: https://flattenthecurve.co.nz
 
 ---
 

--- a/_resources/2020-03-23-loss-of-sense-of-smell-as-marker-of.md
+++ b/_resources/2020-03-23-loss-of-sense-of-smell-as-marker-of.md
@@ -1,7 +1,7 @@
 ---
 category: Educational content
 name: Loss of sense of smell as marker of COVID-19 infection
-url: https://www.entuk.org/loss-sense-smell-marker-covid-19-infection
+target: https://www.entuk.org/loss-sense-smell-marker-covid-19-infection
 
 ---
 

--- a/_resources/2020-03-23-us-covid-19-mutual-aid-resources.md
+++ b/_resources/2020-03-23-us-covid-19-mutual-aid-resources.md
@@ -2,7 +2,7 @@
 category: community sourced mutual aid links
 country: USA
 name: US COVID-19 Mutual Aid Resources
-url: https://drive.google.com/drive/folders/1dKDM8CA32gZ1L2v_MFewohqJhVnCsi71?usp=sharing
+target: https://drive.google.com/drive/folders/1dKDM8CA32gZ1L2v_MFewohqJhVnCsi71?usp=sharing
 
 ---
 

--- a/_resources/2020-03-24-covid-19-open-source-helpdesk.md
+++ b/_resources/2020-03-24-covid-19-open-source-helpdesk.md
@@ -1,7 +1,7 @@
 ---
 category: Open software support
 name: COVID-19 Open-Source Helpdesk
-url: https://discourse.covid-oss-help.org/
+target: https://discourse.covid-oss-help.org/
 
 ---
 

--- a/_resources/2020-03-24-data-against-covid-19.md
+++ b/_resources/2020-03-24-data-against-covid-19.md
@@ -1,7 +1,7 @@
 ---
 category: Data Science support
 name: Data Against COVID-19
-url: https://www.data-against-covid.org/
+target: https://www.data-against-covid.org/
 
 ---
 

--- a/_resources/2020-03-25-corona-virus-full-fact-news-checkin.md
+++ b/_resources/2020-03-25-corona-virus-full-fact-news-checkin.md
@@ -1,7 +1,7 @@
 ---
 category: Educational content
 name: Corona Virus - Full Fact - News checking organisation
-url: https://fullfact.org/health/coronavirus/?utm_source=homepage&utm_medium=trending
+target: https://fullfact.org/health/coronavirus/?utm_source=homepage&utm_medium=trending
 
 ---
 

--- a/_resources/2020-03-27-coronavirus-the-science-explained.md
+++ b/_resources/2020-03-27-coronavirus-the-science-explained.md
@@ -1,7 +1,7 @@
 ---
 category: Scientific publication
 name: 'Coronavirus: the science explained'
-url: https://coronavirusexplained.ukri.org/en/
+target: https://coronavirusexplained.ukri.org/en/
 
 ---
 

--- a/_resources/2020-03-27-covid-19-research-search-engine.md
+++ b/_resources/2020-03-27-covid-19-research-search-engine.md
@@ -1,7 +1,7 @@
 ---
 category: Scientific publication
 name: COVID-19 Research Search Engine
-url: https://covidsmartsearch.recital.ai
+target: https://covidsmartsearch.recital.ai
 
 ---
 

--- a/_resources/2020-03-27-why-you-must-act-now-by-state.md
+++ b/_resources/2020-03-27-why-you-must-act-now-by-state.md
@@ -2,7 +2,7 @@
 category: Model or Simulation
 country: USA
 name: Why you must act now - By State
-url: https://covidactnow.org
+target: https://covidactnow.org
 
 ---
 

--- a/_resources/2020-03-28-covid-19-spread-vs-healthcare-capac.md
+++ b/_resources/2020-03-28-covid-19-spread-vs-healthcare-capac.md
@@ -1,7 +1,7 @@
 ---
 category: model
 name: COVID-19 Spread vs Healthcare Capacity
-url: https://alhill.shinyapps.io/COVID19seir/
+target: https://alhill.shinyapps.io/COVID19seir/
 
 ---
 

--- a/_resources/2020-03-28-covid19-day-by-day.md
+++ b/_resources/2020-03-28-covid19-day-by-day.md
@@ -1,7 +1,7 @@
 ---
 category: Educational content
 name: Covid19 day by day
-url: https://www.businessinsider.com/novel-coronavirus-covid-19-symptoms-day-by-day-2020-3
+target: https://www.businessinsider.com/novel-coronavirus-covid-19-symptoms-day-by-day-2020-3
 
 ---
 

--- a/_resources/2020-03-28-epidemic-calculator.md
+++ b/_resources/2020-03-28-epidemic-calculator.md
@@ -1,7 +1,7 @@
 ---
 category: model
 name: Epidemic Calculator
-url: http://gabgoh.github.io/COVID/index.html
+target: http://gabgoh.github.io/COVID/index.html
 
 ---
 

--- a/_resources/2020-03-28-ministerio-de-salud-de-la-nacin.md
+++ b/_resources/2020-03-28-ministerio-de-salud-de-la-nacin.md
@@ -2,7 +2,7 @@
 category: gov
 country: Argentina
 name: "Ministerio de Salud de la Naci\xF3n"
-url: https://www.argentina.gob.ar/salud/coronavirus-COVID-19
+target: https://www.argentina.gob.ar/salud/coronavirus-COVID-19
 
 ---
 

--- a/_resources/2020-03-28-world-health-organization.md
+++ b/_resources/2020-03-28-world-health-organization.md
@@ -1,7 +1,7 @@
 ---
 category: gov
 name: World Health Organization
-url: https://www.who.int/health-topics/coronavirus
+target: https://www.who.int/health-topics/coronavirus
 
 ---
 

--- a/_resources/2020-03-29-coronavirus-disease-covid-19-statis.md
+++ b/_resources/2020-03-29-coronavirus-disease-covid-19-statis.md
@@ -1,7 +1,7 @@
 ---
 category: Chart, visualization, infographic
 name: "Coronavirus Disease (COVID-19) \u2013 Statistics and Research"
-url: https://ourworldindata.org/coronavirus
+target: https://ourworldindata.org/coronavirus
 
 ---
 

--- a/_resources/2020-04-03-brief-video-explaining-why-flatteni.md
+++ b/_resources/2020-04-03-brief-video-explaining-why-flatteni.md
@@ -1,7 +1,7 @@
 ---
 category: Educational content
 name: Brief video explaining why flattening the curve is important
-url: https://www.youtube.com/watch?v=fgBla7RepXU
+target: https://www.youtube.com/watch?v=fgBla7RepXU
 
 ---
 

--- a/_resources/2020-04-03-co-mask.md
+++ b/_resources/2020-04-03-co-mask.md
@@ -1,7 +1,7 @@
 ---
 category: Educational content
 name: Co-MASK
-url: https://co-mask.github.io/
+target: https://co-mask.github.io/
 
 ---
 

--- a/_resources/2020-04-03-coronavirus-the-science-explained.md
+++ b/_resources/2020-04-03-coronavirus-the-science-explained.md
@@ -1,7 +1,7 @@
 ---
 category: Educational content
 name: 'Coronavirus: the science explained'
-url: https://coronavirusexplained.ukri.org/
+target: https://coronavirusexplained.ukri.org/
 
 ---
 

--- a/_resources/2020-04-03-makermask.md
+++ b/_resources/2020-04-03-makermask.md
@@ -1,7 +1,7 @@
 ---
 category: Educational content
 name: MakerMask
-url: http://makermask.org/
+target: http://makermask.org/
 
 ---
 

--- a/_resources/2020-04-03-the-covid-tracking-project.md
+++ b/_resources/2020-04-03-the-covid-tracking-project.md
@@ -2,7 +2,7 @@
 category: Chart, visualization, infographic
 country: USA
 name: The COVID Tracking Project
-url: https://covidtracking.com/
+target: https://covidtracking.com/
 
 ---
 

--- a/_resources/2020-04-03-where-to-safely-shop-during-covid-1.md
+++ b/_resources/2020-04-03-where-to-safely-shop-during-covid-1.md
@@ -3,7 +3,7 @@ category: Educational content
 country: USA
 name: Where to Safely Shop during Covid-19
 state: MA
-url: http://helptofight.org/shopsafely
+target: http://helptofight.org/shopsafely
 
 ---
 

--- a/resources.md
+++ b/resources.md
@@ -23,7 +23,7 @@ If you want to contribute to this list, you can do it [here](https://forms.gle/2
     {% endif %}
   {% endif %}
 
-###  <a href="{{ resource.url }}">{{ resource.name }}</a>
+###  <a href="{{ resource.target }}">{{ resource.name }}</a>
   <p>{{ resource.content | markdownify }}</p>
 
 {% endfor %}


### PR DESCRIPTION
I guess I now know why URL in resource attributes was uppercase. Turns out that resource.url contains location of the underlying md file and can't be populated by the file contents. I have switched to use target instead. This should fix the links. 

Changes to the spreadsheet and resource_import.py will follow.