### PR TITLE
Fix import_resources.py to use target instead of url

### DIFF
--- a/_scripts/import_resources.py
+++ b/_scripts/import_resources.py
@@ -22,7 +22,7 @@ args = parser.parse_args()
 REQUIRED_COLUMNS = ['name', 'category', 'description']
 """These columns must be non-empty for the row to be accepted."""
 
-EXTRACT_ATTRIBUTES = ['name', 'category', 'country', 'state', 'url']
+EXTRACT_ATTRIBUTES = ['name', 'category', 'country', 'state', 'target']
 """Columns that will be added into MD file as attributes, in this order."""
 
 


### PR DESCRIPTION
Second part of https://github.com/flattenthecurve/guide/issues/312. Fixes resource automation script. The underlying spreadsheet has already been converted to use target column name. 