### PR TITLE
Add scientific review needed include

### DIFF
--- a/_includes/disclaimer/cs/disclaimer.md
+++ b/_includes/disclaimer/cs/disclaimer.md
@@ -1,0 +1,1 @@
+*New content: This translation has not yet been verified by a scientist, if you can help please register [here](https://forms.gle/aPtMHFstGb5Dpod99).*

--- a/_includes/disclaimer/de/disclaimer.md
+++ b/_includes/disclaimer/de/disclaimer.md
@@ -1,0 +1,1 @@
+*New content: This translation has not yet been verified by a scientist, if you can help please register [here](https://forms.gle/aPtMHFstGb5Dpod99).*

--- a/_includes/disclaimer/el/disclaimer.md
+++ b/_includes/disclaimer/el/disclaimer.md
@@ -1,0 +1,1 @@
+*New content: This translation has not yet been verified by a scientist, if you can help please register [here](https://forms.gle/aPtMHFstGb5Dpod99).*

--- a/_includes/disclaimer/en/disclaimer.md
+++ b/_includes/disclaimer/en/disclaimer.md
@@ -1,0 +1,1 @@
+*New content: This translation has not yet been verified by a scientist, if you can help please register [here](https://forms.gle/aPtMHFstGb5Dpod99).*

--- a/_includes/disclaimer/es/disclaimer.md
+++ b/_includes/disclaimer/es/disclaimer.md
@@ -1,0 +1,1 @@
+*New content: This translation has not yet been verified by a scientist, if you can help please register [here](https://forms.gle/aPtMHFstGb5Dpod99).*

--- a/_includes/disclaimer/fr/disclaimer.md
+++ b/_includes/disclaimer/fr/disclaimer.md
@@ -1,0 +1,1 @@
+*New content: This translation has not yet been verified by a scientist, if you can help please register [here](https://forms.gle/aPtMHFstGb5Dpod99).*

--- a/_includes/disclaimer/it/disclaimer.md
+++ b/_includes/disclaimer/it/disclaimer.md
@@ -1,0 +1,1 @@
+*New content: This translation has not yet been verified by a scientist, if you can help please register [here](https://forms.gle/aPtMHFstGb5Dpod99).*

--- a/_includes/disclaimer/mr/disclaimer.md
+++ b/_includes/disclaimer/mr/disclaimer.md
@@ -1,0 +1,1 @@
+*New content: This translation has not yet been verified by a scientist, if you can help please register [here](https://forms.gle/aPtMHFstGb5Dpod99).*

--- a/_includes/disclaimer/ru/disclaimer.md
+++ b/_includes/disclaimer/ru/disclaimer.md
@@ -1,0 +1,1 @@
+*New content: This translation has not yet been verified by a scientist, if you can help please register [here](https://forms.gle/aPtMHFstGb5Dpod99).*

--- a/_sass/minima/_act_prepare.scss
+++ b/_sass/minima/_act_prepare.scss
@@ -44,6 +44,13 @@
   }
 }
 
+.disclaimer {
+    border: 5px solid rgb(241, 182, 20);
+    font-size: 80%;
+    padding: 5px;
+    margin: 10px;
+}
+
 /**
  *  ToC
  */


### PR DESCRIPTION
Hello! I'm new here so feel free to disregard this PR if it is not aligned with your best practices or you'd prefer a different solution. :)

Addresses part of https://github.com/flattenthecurve/guide/issues/318

By simply adding the include disclaimer below to any post in act_and_prepare
```
{:.disclaimer}
{% include disclaimer/en/disclaimer.md %}
```

The following notes can appear:
1. Needs scientific review note at the top of the page
![image](https://user-images.githubusercontent.com/8293542/79302756-17f5ae00-7ea2-11ea-8990-ee1d3ecfb8e8.png)

2. Needs scientific review note individual sections (posts)
![image](https://user-images.githubusercontent.com/8293542/79302925-7cb10880-7ea2-11ea-894c-e9f9ff01a4c2.png)

If approved, all the disclaimer.md files would need translations into the target language.

This PR does not address the other needs mentioned in the linked issue:
- A way to list translators for each language
- Any special deployment mechanism that decides if the notes should be included or not. That is left up to manually editing the section/page content with the {includes} statement.