### PR TITLE
Disclaimer for missing scientific review

### DIFF
--- a/_data/en/strings.yml
+++ b/_data/en/strings.yml
@@ -17,3 +17,6 @@ so-far: Covid-19 (so far)
 estimate: Covid-19 (estimate)
 bottom-estimate: Covid-19 (bottom of estimate range)
 seasonal-flu: Seasonal flu
+pending-sci-review: >-
+  *New content: This translation has not yet been verified by a scientist.
+  If you can help please register [here](https://forms.gle/aPtMHFstGb5Dpod99).*

--- a/_includes/pending-sci-review.html
+++ b/_includes/pending-sci-review.html
@@ -1,0 +1,5 @@
+{% if site.data[site.active_lang].strings['pending-sci-review'] %}
+<p class="disclaimer" markdown="1">
+  {{ site.data[site.active_lang].strings['pending-sci-review'] }}
+</p>
+{% endif %}

--- a/_sass/minima/_act_prepare.scss
+++ b/_sass/minima/_act_prepare.scss
@@ -44,6 +44,13 @@
   }
 }
 
+.disclaimer {
+  border: 5px solid rgb(241, 182, 20);
+  font-size: 80%;
+  padding: 5px;
+  margin: 10px;
+}
+
 /**
  *  ToC
  */


### PR DESCRIPTION
This work is derived from a prototype by @kendrahavens. The placement of the notice, text and the styling is theirs. I have incorporated feedback from @matiasgarciaisaia about how to deal with string translations.

This consist of:
1. pending-sci-review string that should be soon translated into all target languages
2. _include/pending-sci-review.html notice that can be included in md files. Notice will only show up if the content has been translated into the current language.
3. css style for the notice

I'm working on modifications to the `import_language.rb` script that will insert the disclaimer notices into files when it detects that they have not been scientifically reviewed.