### PR TITLE
Refactor import_languages.rb script and allow for optional pending-sci-review

### DIFF
--- a/import-translations.sh
+++ b/import-translations.sh
@@ -8,4 +8,7 @@
 #
 # This command will generate the _translations/<LANG>.json files and the _content/<LANG>
 
-docker-compose run --rm web /bin/bash -c "(bundle check || bundle install --jobs=3) && ruby import_language.rb $1 $2"
+docker-compose run \
+    --user $(id -u):$(id -g) \
+    --rm web \
+    /bin/bash -c "(bundle check || bundle install --jobs=3) && ruby import_language.rb $1 $2"

--- a/import_language.rb
+++ b/import_language.rb
@@ -13,7 +13,7 @@ require_relative '_plugins/common'
 
 $options = {}
 OptionParser.new do |opts|
-  $options[:sci_review_notice] = true
+  $options[:sci_review_notice] = false
 
   opts.on("-r", "--[no-]sci-review-notice", "Include notices about pending scientific reviews.") do |r|
     $options[:sci_review_notice] = r

--- a/import_language.rb
+++ b/import_language.rb
@@ -133,7 +133,7 @@ puts "Translations fetched: #{all_translations.keys}"
 
 puts "Writing translation files"
 all_translations.each {|lang, json| 
-    File.open("_translations/#{lang}.json", "w:UTF-8") { |f| f.write(json) }
+    File.open("_translations/#{lang}.json", "w:UTF-8") { |f| f.write(JSON.pretty_generate(json)) }
 }
 
 all_translations.each {|lang, translations|

--- a/import_language.rb
+++ b/import_language.rb
@@ -5,12 +5,17 @@ require 'ruby-lokalise-api'
 require 'open-uri'
 require 'zip'
 require 'metadown'
+require 'set'
 require 'yaml'
 require_relative '_plugins/common'
 
 def language_dir(lang)
   "_sections/*/#{lang}"
 end
+
+LOKALISE_TOKEN = ARGV[0]
+SINGLE_LANG = ARGV[1]
+LOKALISE_PROJECT_ID = "423383895e6b8c4b081a89.98184174"
 
 SOURCE_LANG = "en"
 SOURCE_DIR = language_dir(SOURCE_LANG)
@@ -31,9 +36,7 @@ CONFIG_YML = File.open("_config.yml", 'r:UTF-8') { |f| f.read }
 SUPPORTED_LANGS = YAML.load(CONFIG_YML)['languages']
 NEW_LANGS = []
 
-def generate_content(translations_lang, translations_file)
-  translations = JSON.parse(File.open(translations_file, 'r:UTF-8') { |f| f.read })
-
+def generate_content(translations_lang, translations, no_review_keys: [])
   FileUtils.rm_r(Dir[language_dir(translations_lang)], force: true)
 
   SECTIONS_TO_FILES.each do |section, source_file|
@@ -41,12 +44,26 @@ def generate_content(translations_lang, translations_file)
     translated_dir = File.dirname(translated_file)
     FileUtils.mkdir_p(translated_dir)
     File.open(translated_file, "w:UTF-8") { |file|
-      file.puts translations[section]
+      content = translations[section]
+      # Right now, disclaimers are only added to act_and_prepare
+      if translated_dir =~ /act_and_prepare/ and no_review_keys.include? section
+        puts "Adding scientific-review disclaimer to #{translations_lang} #{section}"
+        # Insert disclaimer after the last h2 line.
+        lines = content.lines
+        last_hdr = lines.rindex{|e| e =~ /^##/}
+        if last_hdr == nil
+            last_hdr = 0
+        else
+            last_hdr = last_hdr + 1
+        end
+        lines.insert(last_hdr, "\n{% pending-sci-review.html %}\n")
+        content = lines.join("")
+      end
+      file.puts content
     }
   end
 
   TOP_LEVEL_PAGES.each do |page, source_file|
-    puts "source_file: #{source_file}"
     source_content = File.open(source_file, 'r:UTF-8') { |f| f.read }
     metadata = Metadown.render(source_content).metadata
     metadata["lang"] = translations_lang
@@ -62,41 +79,64 @@ def generate_content(translations_lang, translations_file)
   translated_strings_dir = "_data/#{translations_lang}"
   translated_strings = Hash[STRINGS.map { |key, value| [key, translations[key]] }]
   FileUtils.mkdir_p(translated_strings_dir)
-  File.open("#{translated_strings_dir}/strings.yml", 'w:UTF-8') { |f| f.puts translated_strings.to_yaml }
+  File.open("#{translated_strings_dir}/strings.yml", 'w:UTF-8') {|f| f.puts translated_strings.to_yaml }
   NEW_LANGS << translations_lang unless SUPPORTED_LANGS.include? translations_lang
 end
 
-LOKALISE_TOKEN = ARGV[0]
-SINGLE_LANG = ARGV[1]
-PROJECT_ID = "423383895e6b8c4b081a89.98184174"
-client = Lokalise.client LOKALISE_TOKEN
-
-puts "Building files from Lokalise"
-response = client.download_files(PROJECT_ID, {format: "json", filter_filenames: ["pasted.json"], replace_breaks: false, placeholder_format: :icu})
-
-puts "Downloading #{response["bundle_url"]} ..."
-content = open(response["bundle_url"])
-Zip::File.open_buffer(content) do |zip|
-  zip.each do |entry|
-    next unless entry.name.end_with?("pasted.json")
-    next if entry.name.end_with?("#{SOURCE_LANG}/pasted.json")
-    lang = entry.name.split("/")[0]
-    next if SINGLE_LANG != nil && lang != SINGLE_LANG
-    dest = "_translations/#{lang}.json"
-    puts "Saving #{dest}"
-    entry.extract(dest) { true }
-
-    puts "Expanding .md"
-    generate_content(lang, dest)
-  end
+def fetch_json_from_lokalise(lang: nil, filter_data: ['translated'])
+    client = Lokalise.client LOKALISE_TOKEN
+    params = {
+      format: "json",
+      filter_filename: ["pasted.json"],
+      replace_breaks: false,
+      placeholder_format: :icu,
+      filter_data: filter_data
+    }
+    if lang != nil
+      params['filter_langs'] = [lang]
+    end
+    resp = client.download_files(LOKALISE_PROJECT_ID, params)
+    result = {}
+    # TODO: can this be replaced with plain Zip::File.open(resp["bundle_url"])
+    Zip::File.open_buffer(open(resp["bundle_url"])) { |zip|
+      zip.each do |entry|
+        next unless entry.name.end_with?("pasted.json")
+        file_lang = entry.name.split("/")[0]
+        result[file_lang] = JSON.parse(entry.get_input_stream.read)
+      end
+    }
+    result
 end
 
+def keys_without_reviews(everything, reviewed)
+    everything.keys.to_set - reviewed.keys.to_set
+end
+
+
+puts "Fetching translations from Lokalise"
+all_translations = fetch_json_from_lokalise(lang: SINGLE_LANG)
+all_reviews = fetch_json_from_lokalise(lang: SINGLE_LANG, filter_data: ['reviewed']) 
+
+puts "Translations fetched: #{all_translations.keys}"
+
+puts "Writing translation files"
+all_translations.each {|lang, json| 
+    File.open("_translations/#{lang}.json", "w:UTF-8") { |f| f.write(json) }
+}
+
+all_translations.each {|lang, translations|
+  reviews = all_reviews[lang]
+  not_reviewed = keys_without_reviews(translations, reviews)
+  puts "Generating content files for language #{lang}"
+  generate_content(lang, translations, no_review_keys: not_reviewed)
+}
+
 unless NEW_LANGS.empty?
-  puts "Langs to add: #{NEW_LANGS}"
+  puts "Languages to add: #{NEW_LANGS}"
   languages_regex = /^languages: (\[.*\])$/
   if CONFIG_YML =~ languages_regex
     new_languages_line = "languages: #{(SUPPORTED_LANGS + NEW_LANGS).to_s}"
-    NEW_CONFIG_YML = CONFIG_YML.sub languages_regex, new_languages_line
-    File.open('_config.yml', 'w:UTF-8') { |f| f.puts NEW_CONFIG_YML }
+    new_config_yml = CONFIG_YML.sub languages_regex, new_languages_line
+    File.open('_config.yml', 'w:UTF-8') { |f| f.puts new_config_yml }
   end
 end


### PR DESCRIPTION
The core of this change is to allow inserting pending-sci-review notice to act_and_prepare articles. To allow for this, the structure of the language import script has been refactored so that this could be done relatively cleanly.

Here's the brief summary of the changes:
1. added --sci-review-notice flag which will trigger insertion of pending-sci-review notices for translations that are not marked as reviewed in Lokalise
2. Refactoring of the code that pulls translations from Lokalise. The code has been moved to a function which allows us to specify whether we want to retrieve translations or only reviewed keys. The code returns JSON instead of generating local files under `_translations/` and the method is called twice by default to find out which keys are not scientifically reviewed.
3. Files under `_translations/` are now generated from in-memory json. This generates *almost* the same content but results in some whitespace changes.
4. If SINGLE_LANG is specified, request to Lokalise will only fetch the translations for given language (minor optimization).

As far as the sci-review-pending notice goes, this will get inserted into the translated text after the last header line (or at the beginning of the file if no headers are found). This is somewhat strange but it seems to be the only way to get the notice in the right place. Unless we make some dramatic changes to the styling of these markdown files that would remove all headers this should work just fine.