### PR TITLE
Resource pre commit checks

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -1,0 +1,10 @@
+repos:
+- repo: local
+  hooks:
+  - id: pre-commit-resources
+    name: Disallow manual modifications to resource files
+    stages: [commit]
+    entry: ./_scripts/pre-commit-warn-on-resources.sh
+    language: script
+    files: _resources/
+    types: [markdown]

--- a/_resources/2020-04-03-makermask.md
+++ b/_resources/2020-04-03-makermask.md
@@ -5,4 +5,6 @@ target: http://makermask.org/
 
 ---
 
+MAKING SOME CHANGES HERE.
+
 MakerMask is a source for science-based mask designs for community makers to combat the spread of COVID-19. It is important that we use the best information possible to help protect ourselves and our communities. The MakerMask designs use latex-free, water-resistant materials that are likely to provide improved protection over cotton and elastic.  We need makers/sewists/helpers of all abilities to begin ramping up production to meet community needs.

--- a/_resources/2020-04-03-makermask.md
+++ b/_resources/2020-04-03-makermask.md
@@ -5,6 +5,4 @@ target: http://makermask.org/
 
 ---
 
-MAKING SOME CHANGES HERE.
-
 MakerMask is a source for science-based mask designs for community makers to combat the spread of COVID-19. It is important that we use the best information possible to help protect ourselves and our communities. The MakerMask designs use latex-free, water-resistant materials that are likely to provide improved protection over cotton and elastic.  We need makers/sewists/helpers of all abilities to begin ramping up production to meet community needs.

--- a/_scripts/pre-commit-warn-on-resources.sh
+++ b/_scripts/pre-commit-warn-on-resources.sh
@@ -1,0 +1,13 @@
+#!/bin/sh
+#
+# Issue warning if modifications to _resource md files are present.
+
+# Redirect output to stderr
+exec 1>&2
+
+if test $(git diff --cached --name-only | grep _resources/ | wc -l) != 0
+then
+    echo "!!! DO NOT MODIFY RESOURCES BY HAND !!!"
+    echo "Use https://forms.gle/2zi67brmMZ7byCvb8 instead."
+    exit 1
+fi


### PR DESCRIPTION
add pre-commit checks that will disallow manual modifications to _resources files and point people to the form. Unfortunately this will still need to be set-up by collaborators by installing pre-submit and activating on their local forks/clones by running this sequence:

```
pip install pre-commit
pre-commit install
```

I'm also working on a workflow that would send people to the form when they send PRs modifying _resources/ which might catch those that may not be caught by the pre-commit check.

It seems to me that pre-commit may be used for other Q&A tasks (e.g. limited markdown linting and such) so we might want to think if we would like to use them by default and create "set up your repo" instructions for collaborators that will ensure that pre-commit hooks are installed and used across the board.