### PR TITLE
Few improvements to the language import script

### DIFF
--- a/_config.yml
+++ b/_config.yml
@@ -51,6 +51,16 @@ exclude:
   - build
 
 languages: ["en", "es", "de", "fr", "it", "el", "ru", "cs", "mr"]
+
+# Configuration for pending-sci-review notices. This is used by the 
+# import_languages.rb script when pulling translations from lokalise.
+
+# This controls whether sci notices are enabled or disabled by default.
+sci_review_notice_config:
+  enabled_by_default: false
+  explicitly_enabled_for_languages: []
+  explicitly_disabled_for_languages: []
+
 default_lang: 'en'
 exclude_from_localization: ['assets', 'css', 'build']
 parallel_localization: false


### PR DESCRIPTION
Mainly around pending-sci-review noticiations.

1. Script crashed for languages that did not have any keys in the reviewed state. This is now fixed.
2. I have consolidated indentation to be 2 spaces everywhere (cosmetic fix only).
3. Removed `--[no-]sci-review-notice` commandline flag and replaced with more flexible configuration block in the `_config.yml`. This allows us to fine tune where we want these notices to be shown.
4. Move the decision logic for whether the notice should be shown into its own function for better readability.
5. Do not show notices in the section header files in act_and_prepare (these were introduced in PR #336)