### PR TITLE
Do not override user when running import-translations.sh

### DIFF
--- a/import-translations.sh
+++ b/import-translations.sh
@@ -9,6 +9,5 @@
 # This command will generate the _translations/<LANG>.json files and the _content/<LANG>
 
 docker-compose run \
-    --user $(id -u):$(id -g) \
     --rm web \
     /bin/bash -c "(bundle check || bundle install --jobs=3) && ruby import_language.rb $1 $2"


### PR DESCRIPTION
While this solves the problem of root-owned files when the script is run locally it messes up things when this script is run from github actions. So I'm removing this.