### PR TITLE
Drop the old domain

### DIFF
--- a/.github/workflows/import-new-resources.yml
+++ b/.github/workflows/import-new-resources.yml
@@ -7,13 +7,13 @@ on:
         - cron: '0 */6 * * *'
 jobs:
   import_resources:
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-24.04
     steps:
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@v4
       - name: Run resource import script
         run: ./_scripts/import_resources.py
       - name: Create pull request
-        uses: peter-evans/create-pull-request@v2
+        uses: peter-evans/create-pull-request@v7
         with:
           token: ${{ secrets.GITHUB_TOKEN }}
           commit-message: Import new resources.

--- a/.github/workflows/preview-translations.yml
+++ b/.github/workflows/preview-translations.yml
@@ -5,10 +5,10 @@ on:
 
 jobs:
   pull_push_preview:
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-24.04
     steps:
-      - uses: actions/checkout@v1
-      - uses: actions/cache@v1
+      - uses: actions/checkout@v4
+      - uses: actions/cache@v4
         with:
           path: ~/cache/bundle
           key: ${{ runner.os }}-gems-${{ hashFiles('**/Gemfile.lock') }}
@@ -32,8 +32,8 @@ jobs:
       - name: Build Jekyll site
         run: |
           mv docker-compose.ci.yml docker-compose.override.yml
-          docker-compose run --rm web /bin/bash -c "(bundle check || bundle install --jobs=3) && bundle exec jekyll build"
-      - uses: amondnet/vercel-action@v19
+          docker compose run --rm web /bin/bash -c "(bundle check || bundle install --jobs=3) && bundle exec jekyll build"
+      - uses: amondnet/vercel-action@v25
         with:
           vercel-token: ${{ secrets.ZEIT_TOKEN }}
           zeit-team-id: ${{ secrets.ZEIT_TEAM_ID }}

--- a/.github/workflows/preview.yml
+++ b/.github/workflows/preview.yml
@@ -8,10 +8,10 @@ on:
 
 jobs:
   build_and_deploy:
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-24.04
     steps:
-      - uses: actions/checkout@v1
-      - uses: actions/cache@v1
+      - uses: actions/checkout@v4
+      - uses: actions/cache@v4
         with:
           path: ~/cache/bundle
           key: ${{ runner.os }}-gems-${{ hashFiles('**/Gemfile.lock') }}
@@ -20,7 +20,7 @@ jobs:
       - name: Build Jekyll site
         run: |
           mv docker-compose.ci.yml docker-compose.override.yml
-          docker-compose run --rm web /bin/bash -c "(bundle check || bundle install --jobs=3) && bundle exec jekyll build"
+          docker compose run --rm web /bin/bash -c "(bundle check || bundle install --jobs=3) && bundle exec jekyll build"
       - uses: amondnet/now-deployment@v2
         with:
           zeit-token: ${{ secrets.ZEIT_TOKEN }}

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -7,10 +7,10 @@ on:
 
 jobs:
   build_and_deploy:
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-24.04
     steps:
-      - uses: actions/checkout@v1
-      - uses: actions/cache@v1
+      - uses: actions/checkout@v4
+      - uses: actions/cache@v4
         with:
           path: ~/cache/bundle
           key: ${{ runner.os }}-gems-${{ hashFiles('**/Gemfile.lock') }}
@@ -19,7 +19,7 @@ jobs:
       - name: Build Jekyll site
         run: |
           mv docker-compose.ci.yml docker-compose.override.yml
-          docker-compose run --rm web /bin/bash -c "(bundle check || bundle install --jobs=3) && JEKYLL_ENV=production bundle exec jekyll build"
+          docker compose run --rm web /bin/bash -c "(bundle check || bundle install --jobs=3) && JEKYLL_ENV=production bundle exec jekyll build"
       - name: Publish to gh-pages branch
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
@@ -27,17 +27,17 @@ jobs:
           GITHUB_ACTOR: ${{ secrets.GITHUB_ACTOR }}
         run: ./_scripts/push-to-gh-pages.sh
       - name: Upload English content
-        uses: actions/upload-artifact@v1
+        uses: actions/upload-artifact@v4
         with:
           name: english-content
           path: build/i18n-en.json
 
   publish_to_lokalise:
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-24.04
     needs: build_and_deploy
     steps:
       - name: Download English content
-        uses: actions/download-artifact@v1
+        uses: actions/download-artifact@v4
         with:
           name: english-content
       - name: Push English content to Lokalise

--- a/CNAME
+++ b/CNAME
@@ -1,1 +1,1 @@
-www.flattenthecurve.com
+flattenthecurve.instedd.org

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -70,5 +70,5 @@ We're trying to grow this documentation as fast as we can. This website is based
 #### Running the project locally
 
 1. Clone the project.
-1. Run `docker-compose up`.
+1. Run `docker compose up`.
 1. In a browser, go to `http://localhost:4000`. The site should be running there.

--- a/import-translations.sh
+++ b/import-translations.sh
@@ -8,6 +8,6 @@
 #
 # This command will generate the _translations/<LANG>.json files and the _content/<LANG>
 
-docker-compose run \
+docker compose run \
     --rm web \
     /bin/bash -c "(bundle check || bundle install --jobs=3) && ruby import_language.rb $1 $2"


### PR DESCRIPTION
The old flattenthecurve.com domain is now serving ads, so this commit reverts the Github site to work on an InSTEDD's subdomain.